### PR TITLE
Updates dnode version dependency so as not to fail to build under 4.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
   - 0.12
-  - 4.2
   - 4.3
+  - 5.6
 env:
   - CXX=g++-4.8
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,11 @@ node_js:
   - 0.12
   - 4.2
   - 4.3
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
-  - 0.6
-  - 0.8
+  - 0.12
+  - 4.2
+  - 4.3

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "test" : "tap test/*.js"
     },
     "dependencies" : {
-        "dnode" : "~1.0.1"
+        "dnode" : ">= 1.2.2"
     },
     "devDependencies" : {
         "tap" : "~0.2.6"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name" : "upnode",
     "description" : "transactional connection queue for dnode",
-    "version" : "0.4.3",
+    "version" : "0.5.0",
     "repository" : {
         "type" : "git",
         "url" : "git://github.com/substack/upnode.git"
@@ -29,7 +29,7 @@
         "tap" : "~0.2.6"
     },
     "engines" : {
-        "node" : ">=0.4.0"
+        "node" : ">=0.12.0"
     },
     "license" : "MIT",
     "author" : {


### PR DESCRIPTION
The 1.0.x version of `dnode` fails to build under nodejs 4.3.+ because of the dependency on an old version of `weak`.